### PR TITLE
Add buttons to change rule order

### DIFF
--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 		  text-rendering: optimizeLegibility;
       }
 	  button {
-		  font-size: 1.25rem;
+		  font-size: 1rem;
 	  }
 	  div.control button {
 		  height: 2.5rem;
@@ -151,7 +151,13 @@
 		</td>
 		<td>
 		  <button class="delete_row browser-style" type="button" title="Delete rule">
-			<b>-</b>
+			<b>❌</b>
+		  </button>
+		  <button class="up_row browser-style" type="button" title="Move up">
+			<b>🔼</b>
+		  </button>
+		  <button class="down_row browser-style" type="button" title="Move down">
+			<b>🔽</b>
 		  </button>
 		</td>
       </tr>

--- a/options.js
+++ b/options.js
@@ -69,24 +69,25 @@ function createDomainRow(hostname, act, referer)
 	host.value = hostname;
 	ref.value = referer;
 	selectOption(action, act);
-	return document.importNode(template.content, true);
+	let node = document.importNode(template.content, true);
+	let del = node.querySelector(".delete_row");
+	del.addEventListener("click",
+					   function()
+					   {
+						   del.parentElement.parentElement.remove();
+					   },
+					   { once: true });
+	return node;
 }
 
 
 
 /*
- * Add an empty domain row and configure the delete button.
+ * Add an empty domain row.
  */
 function addDomainRow()
 {
 	let row = createDomainRow("", "replace", "");
-	let b = row.querySelector(".delete_row");
-	b.addEventListener("click",
-					   function()
-					   {
-						   b.parentElement.parentElement.remove();
-					   },
-					   { once: true });
 	let act = row.querySelector(".action");
 	act.addEventListener("change", actionSelectListener);
 	document.getElementById("hosts").appendChild(row);
@@ -140,16 +141,6 @@ function restoreOptions()
 			}
 		}
 
-		/* Enable delete buttons for domain rows */
-		for (let b of hosts.getElementsByClassName("delete_row"))
-		{
-			b.addEventListener("click",
-							   function()
-							   {
-								   b.parentElement.parentElement.remove();
-							   },
-							   { once: true });
-		}
 		/* Disable "Referer" field if the selected action does not use it. */
 		for (let act of hosts.getElementsByClassName("action"))
 		{

--- a/options.js
+++ b/options.js
@@ -70,13 +70,41 @@ function createDomainRow(hostname, act, referer)
 	ref.value = referer;
 	selectOption(action, act);
 	let node = document.importNode(template.content, true);
+
 	let del = node.querySelector(".delete_row");
-	del.addEventListener("click",
-					   function()
-					   {
-						   del.parentElement.parentElement.remove();
-					   },
-					   { once: true });
+	del.addEventListener(
+		"click",
+		function()
+		{
+			del.parentElement.parentElement.remove();
+		},
+		{ once: true });
+
+	let up = node.querySelector(".up_row");
+	up.addEventListener(
+		"click",
+		function()
+		{
+			let row = up.parentElement.parentElement;
+			let prev = row.previousElementSibling;
+			if (prev != null && prev.classList.contains("ref_entry"))
+			{
+				prev.before(row);
+			}
+		});
+
+	let down = node.querySelector(".down_row");
+	down.addEventListener(
+		"click",
+		function()
+		{
+			let row = up.parentElement.parentElement;
+			let next = row.nextElementSibling;
+			if (next != null && next.classList.contains("ref_entry"))
+			{
+				next.after(row);
+			}
+		});
 	return node;
 }
 

--- a/testserver/server.go
+++ b/testserver/server.go
@@ -29,7 +29,8 @@ import (
 
 func makeHandler(links []string) func (http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("%v %v %v%v\n", r.RemoteAddr, r.Method, r.Host, r.URL)
+		fmt.Printf("%v %v %v%v\n",
+			r.RemoteAddr, r.Method, r.Host, r.URL.EscapedPath())
 		tmpl_data := struct{
 			H *http.Header
 			Links []string


### PR DESCRIPTION
Currently being able to change the order is for convenience only, but it may be used for prioritization in the future (e.g. when support for regular expressions could lead to multiple matches of the same length).