### PR TITLE
Lint with the Mozilla web-ext tool

### DIFF
--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -42,7 +42,8 @@ jobs:
           docker-compose down
         working-directory: testserver/
 
-  lint:
+  eslint:
+    name: ESLint
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -53,3 +54,16 @@ jobs:
         run: npm install eslint
       - name: Run ESLint
         run: npx eslint .
+
+  web-ext-lint:
+    name: web-ext lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Install web-ext
+        run: npm install web-ext
+      - name: Run web-ext
+        run: npx web-ext lint --warnings-as-errors

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,6 @@
 	"homepage_url": "https://github.com/airtower-luna/referer-mod",
 	"default_locale": "en",
 
-	"icons": {
-	},
-
 	"permissions": [
 		"webRequest",
 		"webRequestBlocking",

--- a/testserver/docker-compose.yaml
+++ b/testserver/docker-compose.yaml
@@ -3,7 +3,7 @@ x-command: &testcmd
   - '--port'
   - '80'
   - '--links'
-  - 'http://www.x.test,http://web.x.test,http://www.y.test,http://site.y.test'
+  - 'http://www.x.test,http://web.x.test,http://www.y.test,http://site.y.test,http://a.b.y.test'
 services:
   test1:
     build:
@@ -23,6 +23,7 @@ services:
         aliases:
           - www.y.test
           - site.y.test
+          - a.b.y.test
   proxy:
     build:
       context: proxy/


### PR DESCRIPTION
This should help avoid surprise issues like with the v0.11 release (see [v0.11.1 release notes](https://github.com/airtower-luna/referer-mod/releases/tag/v0.11.1)). :relieved: 