### PR TITLE
Download JSON blob when user clicks "export config"

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -131,10 +131,6 @@
 		"message": "Konfiguration exportieren",
 		"description": "Export configuration button"
 	},
-	"config export link": {
-		"message": "Bitte speichern Sie diese JSON-Datei:",
-		"description": "Message with link to JSON configuration blob. Make sure to include the id when translating!"
-	},
 	"select import file": {
 		"message": "Sicherungsdatei zum Import auswählen",
 		"description": "File selector for configration import"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -143,10 +143,6 @@
 		"message": "Export configuration",
 		"description": "Export configuration button"
 	},
-	"config export link": {
-		"message": "Please save this JSON file:",
-		"description": "Message with link to JSON configuration blob. Make sure to include the id when translating!"
-	},
 	"select import file": {
 		"message": "Choose backup file to import",
 		"description": "File selector for configration import"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -143,10 +143,6 @@
 		"message": "Экспорт конфигурации",
 		"description": "Export configuration button"
 	},
-	"config export link": {
-		"message": "Сохраните этот JSON-файл:",
-		"description": "Message with link to JSON configuration blob. Make sure to include the id when translating!"
-	},
 	"select import file": {
 		"message": "Выберите файл резервной копии для импорта",
 		"description": "File selector for configration import"

--- a/options.html
+++ b/options.html
@@ -85,10 +85,6 @@
         <div class="control">
           <button class="browser-style i18n-text" type="button" id="export">config export button</button>
         </div>
-        <div id="export_text" hidden>
-          <span class="i18n-text">config export link</span>
-          <a id="export_blob"></a>
-        </div>
       </p>
       <p>
         <div class="browser-style">

--- a/options.js
+++ b/options.js
@@ -237,12 +237,11 @@ function exportConfig()
 			let blob = new Blob([JSON.stringify(exportConf, null, 2)],
 				{ type: "application/json" });
 			let url = URL.createObjectURL(blob);
-			let link = document.querySelector("#export_blob");
+			let link = document.createElement("a");
 			link.href = url;
 			let date = new Date().toISOString().replaceAll(":", "_");
 			link.download = `referer_mod_config-${date}.json`;
-			link.innerText = `referer_mod_config-${date}.json`;
-			document.querySelector("#export_text").hidden = false;
+			link.dispatchEvent(new MouseEvent("click"));
 		}, null);
 }
 


### PR DESCRIPTION
Turns out it's possible to simulate a click on the download link. :sweat_smile: That
way the user immediately sees the download dialog instead of having to
click a link themselves.