### PR TITLE
Implement origin domain matching

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -39,6 +39,7 @@ rules:
     - warn
     - code: 78
       tabWidth: 4
+      ignoreTemplateLiterals: true
       ignoreUrls: true
   no-trailing-spaces:
     - error

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,7 +6,7 @@ env:
   webextensions: yes
 
 parserOptions:
-  ecmaVersion: 10
+  ecmaVersion: 13
 
 rules:
   semi:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Referer Modifier is a Web Extension for Firefox to modify the Referer header in 
 * Remove: Send no Referer at all
 * Replace: Replace the Referer with a configured value
 
+Rules can optionally be limited to apply only to requests from certain origin domains.
+
 You can configure default actions for requests originating from the same domain, and any other request not matching a domain rule. The "replace" and "target" actions will create a Referer header if necessary, the others only modify or remove existing ones. The configuration can be exported as and imported from JSON files.
 
 ## Installation

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -31,6 +31,14 @@
 		"message": "Zieldomain des Requests, umfaßt auch Subdomains",
 		"description": "Header for the target domain column"
 	},
+	"origin domain": {
+		"message": "Ursprungsdomain",
+		"description": "Header for the origin domain column"
+	},
+	"origin domain description": {
+		"message": "Domain von der der Request ausgelöst wurde, einschließlich Subdomains. Wenn dieses Feld leer ist gilt die Regel unabhängig von der Ursprungsdomain.",
+		"description": "Header for the origin domain column (tooltip)"
+	},
 	"action column": {
 		"message": "Aktion",
 		"description": "Header for the action column"
@@ -144,7 +152,7 @@
 		"description": "Import configuration button"
 	},
 	"config doc": {
-		"message": "Die genaue Bedeutung der Parameter ist in Tooltips beschrieben. Domain-Regeln gelten auch für Subdomains, wenn mehrere Regeln auf einen Request passen gilt der längere Treffer. Wenn es beispielsweise Regeln für `www.example.com` und `example.com` gibt, wird bei einem Request für `https://www.example.com/` die Erstere angewendet.\nDie Aktionen „Ersetzen“ und „Ziel“ fügen dem Request wenn nötig einen Referer hinzu, die übrigen Aktionen werden nur angewendet wenn der Browser von sich aus einen Referer senden würde.",
+		"message": "Die genaue Bedeutung der Parameter ist in Tooltips beschrieben. Domain-Regeln gelten auch für Subdomains, wenn mehrere Regeln auf einen Request passen gilt der längere Treffer. Wenn es beispielsweise Regeln für `www.example.com` und `example.com` gibt, wird bei einem Request für `https://www.example.com/` die Erstere angewendet. Die Zieldomain hat bei der Auswahl unter mehreren passenden Regeln Priorität gegenüber der Ursprungsdomain, bei gleich langen Treffern bei der Zieldomain wird die Regel mit dem längsten Treffer bei der Zieldomain ausgewählt.\nDie Aktionen „Ersetzen“ und „Ziel“ fügen dem Request wenn nötig einen Referer hinzu, die übrigen Aktionen werden nur angewendet wenn der Browser von sich aus einen Referer senden würde.",
 		"description": "General user documentation on the options page"
 	},
 	"regexp doc summary": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -31,6 +31,14 @@
 		"message": "Domain of the requested URL, also matches subdomains",
 		"description": "Header for the target domain column (tooltip)"
 	},
+	"origin domain": {
+		"message": "Origin Domain",
+		"description": "Header for the origin domain column"
+	},
+	"origin domain description": {
+		"message": "Domain of the origin of the request, also matches subdomains. Leave empty to match all.",
+		"description": "Header for the origin domain column (tooltip)"
+	},
 	"action column": {
 		"message": "Action",
 		"description": "Header for the action column"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -164,7 +164,7 @@
 		"description": "Import configuration button"
 	},
 	"config doc": {
-		"message": "Please check the tooltips for details on the meaning of the configuration fields. Domains also match subdomains, if a request matches multiple rules the longest match is used. For example, if you have separate rules for both `www.example.com` and `example.com`, a request to `https://www.example.com/` will be subject to the former rule.\nThe \"replace\" and \"target\" actions will add a Referer header to the request if necessary, the other actions only take effect if the browser would send one by default.",
+		"message": "Please check the tooltips for details on the meaning of the configuration fields. Domains also match subdomains, if a request matches multiple rules the longest match is used. For example, if you have separate rules for both `www.example.com` and `example.com`, a request to `https://www.example.com/` will be subject to the former rule. When choosing among multiple matching rules the target domain takes priority over the origin domain, among multiple target domain matches with the same length the rule with the longest origin domain match is selected.\nThe \"replace\" and \"target\" actions will add a Referer header to the request if necessary, the other actions only take effect if the browser would send one by default.",
 		"description": "General user documentation on the options page"
 	},
 	"regexp doc summary": {
@@ -172,7 +172,7 @@
 		"description": "Title for the regexp matching documentation"
 	},
 	"regexp doc": {
-		"message": "If the value of the target domain field ends with a `$` it is treated as a regular expression. The `$` is part of the expression, so your expression must match at the end of the domain. If there are multiple matches with the same length, the first rule from top is used.\nNote that regular expressions are used as-is, so consider the start of the URL and subdomain boundaries. For example, `example\\.com$` would match `my-example.com`. If you want to match only `example.com` use `^example\\.com$`, and to match all its subdomains, too use `(^|\\.)example\\.com$`.",
+		"message": "If the value of a domain field ends with a `$` it is treated as a regular expression. The `$` is part of the expression, so your expression must match at the end of the domain. If there are multiple matches with the same length, the first rule from top is used.\nNote that regular expressions are used as-is, so consider the start of the URL and subdomain boundaries. For example, `example\\.com$` would match `my-example.com`. If you want to match only `example.com` use `^example\\.com$`, and to match all its subdomains, too use `(^|\\.)example\\.com$`.",
 		"description": "Regexp matching documentation"
 	}
 }

--- a/engine.js
+++ b/engine.js
@@ -104,7 +104,7 @@ class Rule
 			return null;
 		}
 
-		let origin_len = 0;
+		let origin_len = -1;
 		if (this.#origin != null)
 		{
 			let origin = source != null ? source.hostname : "";

--- a/engine.js
+++ b/engine.js
@@ -29,11 +29,18 @@ class RuleMatch
 		this.#match_len = match_len;
 	}
 
+	/*
+	 * The rule that matched.
+	 */
 	get rule()
 	{
 		return this.#rule;
 	}
 
+	/*
+	 * Determine if this match is better than another one. Currently
+	 * "better" means the longer match for the target domain.
+	 */
 	better(another)
 	{
 		return another == null || this.#match_len > another.#match_len;
@@ -41,6 +48,10 @@ class RuleMatch
 }
 
 
+/*
+ * One rule as defined in the configuration, with expressions compiled
+ * for matching requests.
+ */
 class Rule
 {
 	// regular expression for the target domain
@@ -160,9 +171,9 @@ class RefererModEngine
 	{
 		let target = new URL(url);
 		/* Check if we have a specific configuration for the target
-		* domain, if yes return it. The reduce step chooses the longest
-		* (most precise) match in case we have multiple filter
-		* matches. */
+		 * domain, if yes return it. The reduce step chooses the best
+		 * match in case we have multiple filter matches, as
+		 * determined by RuleMatch.better(). */
 		let match = this.#domains
 			.map(d => d.match(target))
 			.filter(d => d != null)

--- a/engine.js
+++ b/engine.js
@@ -82,12 +82,12 @@ class Rule
 		 * { domain: "www.example.com", action: "keep", referer: "" }
 		 */
 		this.#target = Rule.#createDomainRegex(rule.domain);
-		this.#origin = 'origin' in rule ?
+		this.#origin = "origin" in rule ?
 			Rule.#createDomainRegex(rule.origin) : null;
 		this.#action = rule.action;
 		this.#referer = rule.referer;
 		console.debug(
-			'rule loaded: {target: %s, origin: %s, action: %s, referer: %s}',
+			"rule loaded: {target: %s, origin: %s, action: %s, referer: %s}",
 			this.#target, this.#origin, this.#action, this.#referer);
 	}
 
@@ -107,7 +107,7 @@ class Rule
 		let origin_len = 0;
 		if (this.#origin != null)
 		{
-			let origin = source != null ? source.hostname : '';
+			let origin = source != null ? source.hostname : "";
 			let origin_match = origin.match(this.#origin);
 			if (origin_match == null)
 			{

--- a/engine.js
+++ b/engine.js
@@ -20,6 +20,10 @@
 
 class RefererModEngine
 {
+	#domains;
+	#sameConf;
+	#anyConf;
+
 	constructor(config)
 	{
 		if (!config)
@@ -50,11 +54,11 @@ class RefererModEngine
 		* contains the regular expression compiled form the "domain" field to
 		* include subdomains.
 		*/
-		this._domains = RefererModEngine.createDomainRegex(config.domains);
+		this.#domains = RefererModEngine.createDomainRegex(config.domains);
 		/* Configuration for same domain requests */
-		this._sameConf = config.sameConf;
+		this.#sameConf = config.sameConf;
 		/* Configuration for any other requests */
-		this._anyConf = config.anyConf;
+		this.#anyConf = config.anyConf;
 	}
 
 	/*
@@ -68,7 +72,7 @@ class RefererModEngine
 		* domain, if yes return it. The reduce step chooses the longest
 		* (most precise) match in case we have multiple filter
 		* matches. */
-		let match = this._domains
+		let match = this.#domains
 			.map(d => ({domain: d, match: target.hostname.match(d.regexp)}))
 			.filter(d => d.match != null)
 			.reduce((acc, current) =>
@@ -93,19 +97,19 @@ class RefererModEngine
 
 		if (originUrl === "" || originUrl === null || originUrl === undefined)
 		{
-			return this._anyConf;
+			return this.#anyConf;
 		}
 
 		let source = new URL(originUrl);
 		if (target.hostname === source.hostname)
 		{
 			/* same domain */
-			return this._sameConf;
+			return this.#sameConf;
 		}
 		else
 		{
 			/* default */
-			return this._anyConf;
+			return this.#anyConf;
 		}
 	}
 

--- a/engine.js
+++ b/engine.js
@@ -86,9 +86,11 @@ class Rule
 			Rule.#createDomainRegex(rule.origin) : null;
 		this.#action = rule.action;
 		this.#referer = rule.referer;
-		console.debug(
-			"rule loaded: {target: %s, origin: %s, action: %s, referer: %s}",
-			this.#target, this.#origin, this.#action, this.#referer);
+	}
+
+	toString()
+	{
+		return `{target: ${this.#target}, origin: ${this.#origin}, action: ${this.#action}, referer: ${JSON.stringify(this.#referer)}}`;
 	}
 
 	/*

--- a/engine.js
+++ b/engine.js
@@ -178,16 +178,7 @@ class RefererModEngine
 			.map(d => d.match(target))
 			.filter(d => d != null)
 			.reduce((acc, current) =>
-			{
-				if (current.better(acc))
-				{
-					return current;
-				}
-				else
-				{
-					return acc;
-				}
-			}, null);
+				current.better(acc) ? current : acc, null);
 		if (match != null)
 		{
 			return match.rule;
@@ -226,14 +217,7 @@ class RefererModEngine
 		switch (conf.action)
 		{
 			case "prune":
-				if (!originUrl)
-				{
-					referrer = "";
-				}
-				else
-				{
-					referrer = new URL(originUrl).origin + "/";
-				}
+				referrer = originUrl ? new URL(originUrl).origin + "/" : "";
 				break;
 			case "target":
 				referrer = new URL(url).origin + "/";

--- a/engine.js
+++ b/engine.js
@@ -1,6 +1,6 @@
 /*
  * Referer Modifier: Modify the Referer header in HTTP requests
- * Copyright (C) 2017-2021 Fiona Klute
+ * Copyright (C) 2017-2022 Fiona Klute
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,79 @@
  */
 "use strict";
 /* exported RefererModEngine */
+
+class Rule
+{
+	// regular expression for the target domain
+	#target;
+	// action to take for matching requests
+	#action;
+	// Referer to set for "replace" rule
+	#referer;
+
+	constructor(rule)
+	{
+		/*
+		 * A rule is expected to have this structure in the stored
+		 * configuration:
+		 *
+		 * { domain: "www.example.com", action: "keep", referer: "" }
+		 */
+		this.#target = Rule.#createDomainRegex(rule.domain);
+		this.#action = rule.action;
+		this.#referer = rule.referer;
+	}
+
+	/*
+	 * Match "target" against this rule, return match object. Target
+	 * must be a URL object.
+	 */
+	match(target)
+	{
+		return target.hostname.match(this.#target);
+	}
+
+	get action()
+	{
+		return this.#action;
+	}
+
+	get referer()
+	{
+		return this.#referer;
+	}
+
+	/*
+	 * Escape function from
+	 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+	 */
+	static #escapeRegExp(string)
+	{
+		// eslint-disable-next-line no-useless-escape
+		return string.replace(/[.*+?^${}()|\[\]\\]/g, "\\$&");
+		// $& means the whole matched string
+	}
+
+	/*
+	 * Create regular expressions from domains to also match subdomains.
+	 */
+	static #createDomainRegex(domain)
+	{
+		let pattern;
+		if (domain.endsWith("$"))
+		{
+			pattern = domain;
+		}
+		else
+		{
+			pattern = "(\\.|^)"
+				+ Rule.#escapeRegExp(domain) + "$";
+		}
+		//console.log(`domain '${domain.domain}', pattern: ${pattern}`);
+		return new RegExp(pattern);
+	}
+}
+
 
 class RefererModEngine
 {
@@ -42,19 +115,9 @@ class RefererModEngine
 
 	setConfig(config)
 	{
-		/*
-		* Configuration for specific domains
-		*
-		* Elements are expected to have this structure in the stored
-		* configuration:
-		*
-		* { domain: "www.example.com", action: "keep", referer: "" }
-		*
-		* While loading the configuration, a "regexp" field will be added that
-		* contains the regular expression compiled form the "domain" field to
-		* include subdomains.
-		*/
-		this.#domains = RefererModEngine.createDomainRegex(config.domains);
+		/* Configuration for specific domains. See Rule constructor
+		 * for the expected structure. */
+		this.#domains = config.domains.map(d => new Rule(d));
 		/* Configuration for same domain requests */
 		this.#sameConf = config.sameConf;
 		/* Configuration for any other requests */
@@ -73,7 +136,7 @@ class RefererModEngine
 		* (most precise) match in case we have multiple filter
 		* matches. */
 		let match = this.#domains
-			.map(d => ({domain: d, match: target.hostname.match(d.regexp)}))
+			.map(d => ({domain: d, match: d.match(target)}))
 			.filter(d => d.match != null)
 			.reduce((acc, current) =>
 			{
@@ -151,39 +214,5 @@ class RefererModEngine
 				referrer = originUrl;
 		}
 		return referrer;
-	}
-
-	/*
-	* Escape function from
-	* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-	*/
-	static escapeRegExp(string)
-	{
-		// eslint-disable-next-line no-useless-escape
-		return string.replace(/[.*+?^${}()|\[\]\\]/g, "\\$&");
-		// $& means the whole matched string
-	}
-
-	/*
-	* Create regular expressions from domains to also match subdomains.
-	*/
-	static createDomainRegex(domains)
-	{
-		for (let domain of domains)
-		{
-			let pattern;
-			if (domain.domain.endsWith("$"))
-			{
-				pattern = domain.domain;
-			}
-			else
-			{
-				pattern = "(\\.|^)"
-					+ RefererModEngine.escapeRegExp(domain.domain) + "$";
-			}
-			//console.log(`domain '${domain.domain}', pattern: ${pattern}`);
-			domain.regexp = new RegExp(pattern);
-		}
-		return domains;
 	}
 }

--- a/engine.js
+++ b/engine.js
@@ -56,6 +56,8 @@ class Rule
 {
 	// regular expression for the target domain
 	#target;
+	// regular expression for the origin domain, if any
+	#origin;
 	// action to take for matching requests
 	#action;
 	// Referer to set for "replace" rule
@@ -70,6 +72,8 @@ class Rule
 		 * { domain: "www.example.com", action: "keep", referer: "" }
 		 */
 		this.#target = Rule.#createDomainRegex(rule.domain);
+		this.#origin = 'origin' in rule ?
+			Rule.#createDomainRegex(rule.origin) : null;
 		this.#action = rule.action;
 		this.#referer = rule.referer;
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,7 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "referer-mod@9a5ba22d-c08f-494f-86c2-e9fd04a6a42c",
-			"strict_min_version": "79.0"
+			"strict_min_version": "90.0"
 		}
 	}
 }

--- a/options.html
+++ b/options.html
@@ -20,13 +20,14 @@
           <thead>
             <tr id="header">
               <th title="target domain description" scope="col" class="i18n-text">target domain</th>
+              <th title="origin domain description" scope="col" class="i18n-text">origin domain</th>
               <th title="action column description" scope="col" class="i18n-text">action column</th>
               <th title="replacement referer description" scope="col" class="i18n-text">replacement referer</th>
             </tr>
           </thead>
           <tbody id="hosts">
             <tr>
-              <td class="rule_label i18n-text" title="any rule description">any rule</td>
+              <td class="rule_label i18n-text" title="any rule description" colspan="2">any rule</td>
               <td>
                 <select class="action browser-style" id="any_action">
                   <option class="i18n-text" value="keep" title="keep action description">keep action</option>
@@ -45,7 +46,7 @@
               </td>
             </tr>
             <tr>
-              <td class="rule_label i18n-text" title="same rule description">same rule</td>
+              <td class="rule_label i18n-text" title="same rule description" colspan="2">same rule</td>
               <td>
                 <select class="action browser-style" id="same_action">
                   <option class="i18n-text" value="keep" title="keep action description">keep action</option>
@@ -108,6 +109,14 @@
             <input class="hostname i18n-text" type="text"
                    placeholder="cdn.example.com"
                    title="target domain description"
+                   value=""/>
+          </div>
+        </td>
+        <td>
+          <div class="browser-style">
+            <input class="origin-domain i18n-text" type="text"
+                   placeholder="cdn.example.com"
+                   title="origin domain description"
                    value=""/>
           </div>
         </td>

--- a/options.js
+++ b/options.js
@@ -122,7 +122,7 @@ function createDomainRow(hostname, origin, act, referer)
  */
 function addDomainRow()
 {
-	let row = createDomainRow("", "replace", "");
+	let row = createDomainRow("", "", "replace", "");
 	let act = row.querySelector(".action");
 	act.addEventListener("change", actionSelectListener);
 	document.getElementById("hosts").appendChild(row);

--- a/options.js
+++ b/options.js
@@ -19,11 +19,8 @@
 /* from i18n.js: */
 /* global apply_i18n */
 
-/* Globals: The domain row template and its children */
+/* The domain row template */
 var template = document.querySelector("#ref_row");
-var host = template.content.querySelector(".hostname");
-var action = template.content.querySelector(".action");
-var ref = template.content.querySelector(".referer");
 
 
 
@@ -66,12 +63,19 @@ function actionSelectListener(event)
 /*
  * Create a new domain row with the given content.
  */
-function createDomainRow(hostname, act, referer)
+function createDomainRow(hostname, origin, act, referer)
 {
+	let node = document.importNode(template.content, true);
+	let host = node.querySelector(".hostname");
+	let origin_domain = node.querySelector(".origin-domain");
+	let action = node.querySelector(".action");
+	let ref = node.querySelector(".referer");
+
 	host.value = hostname;
+	origin_domain.value = origin ? origin : "";
 	ref.value = referer;
 	selectOption(action, act);
-	let node = document.importNode(template.content, true);
+
 	apply_i18n(node.firstElementChild);
 
 	let del = node.querySelector(".delete_row");
@@ -167,6 +171,7 @@ function restoreOptions()
 			for (let line of result.domains)
 			{
 				hosts.appendChild(createDomainRow(line.domain,
+												  line.origin,
 												  line.action,
 												  line.referer));
 			}
@@ -198,11 +203,17 @@ function saveOptions()
 		if (host.length > 0)
 		{
 			let act = entry.querySelector(".action");
-			domains.push({
+			let rule = {
 				domain: host,
 				action: act.options[act.selectedIndex].value,
 				referer: entry.querySelector(".referer").value.trim()
-			});
+			};
+			let origin = entry.querySelector(".origin-domain").value.trim();
+			if (origin !== "")
+			{
+				rule.origin = origin;
+			}
+			domains.push(rule);
 		}
 	}
 	let any_action = document.querySelector("#any_action");

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@ body {
     font: message-box;
     display: flex;
     flex-direction: column;
-    max-width: 650px;
+    max-width: 800px;
     margin: 0 auto;
 }
 header {
@@ -12,8 +12,11 @@ table {
     margin-bottom: 3px;
     width: 100%;
 }
-td:nth-child(2) {
+td:nth-child(3) {
     width: 0;
+}
+th:nth-child(4) {
+    min-width: 25%;
 }
 .button_container {
     display: table-cell;

--- a/test.py
+++ b/test.py
@@ -153,6 +153,32 @@ class RefModTest(unittest.TestCase):
             with self.subTest(link=link):
                 self.check_referer(link)
 
+    def testReferersOrigin(self):
+        """test rules with origin"""
+        self.load_config(self.ext_dir / 'test_config_origin.json')
+
+        tests = [
+            # rule with equal target and origin overrides rule for
+            # same target with empty origin
+            testlink('http://www.x.test/page/', 'http://www.x.test/page/',
+                     'http://www.x.test/page/'),
+            # longer target match is used regardless of length of
+            # origin match
+            testlink('http://www.x.test/page/', 'http://web.x.test/page/',
+                     'https://www.example.com/'),
+            # Between rules with the same target and different origin
+            # longer origin wins.
+            testlink('http://site.y.test/page/', 'http://www.y.test/page/',
+                     'Meow'),
+            # Negative regexp match for origin
+            testlink('http://web.x.test/page/', 'http://www.y.test/page/',
+                     'Hello World!'),
+        ]
+
+        for link in tests:
+            with self.subTest(link=link):
+                self.check_referer(link)
+
     def testDeactivate(self):
         self.load_config(self.ext_dir / 'test_config.json')
 

--- a/test_config_origin.json
+++ b/test_config_origin.json
@@ -1,0 +1,46 @@
+{
+  "any": {
+    "action": "prune",
+    "referer": ""
+  },
+  "same": {
+    "action": "keep",
+    "referer": ""
+  },
+  "domains": [
+    {
+      "domain": "x.test",
+      "action": "remove",
+      "referer": ""
+    },
+    {
+      "domain": "x.test",
+      "action": "keep",
+      "referer": "https://www.example.com/",
+      "origin": "x.test"
+    },
+    {
+      "domain": "web.x.test",
+      "action": "replace",
+      "referer": "https://www.example.com/"
+    },
+    {
+      "domain": "y.test",
+      "action": "replace",
+      "referer": "https://www.example.com/",
+      "origin": "y.test"
+    },
+    {
+      "domain": "y.test",
+      "action": "replace",
+      "referer": "Meow",
+      "origin": "site.y.test"
+    },
+    {
+      "domain": "y.test",
+      "action": "replace",
+      "referer": "Hello World!",
+      "origin": "(?<!\\.?y\\.test)$"
+    }
+  ]
+}

--- a/test_config_origin.json
+++ b/test_config_origin.json
@@ -26,6 +26,11 @@
     },
     {
       "domain": "y.test",
+      "action": "keep",
+      "referer": ""
+    },
+    {
+      "domain": "y.test",
       "action": "replace",
       "referer": "https://www.example.com/",
       "origin": "y.test"


### PR DESCRIPTION
Origin matching allows users to let rules apply only to requests originating from certain domains. The origin is the domain that would appear in an unmodified `Referer`.

The rule to apply is selected based on the length of matches in the target and origin domains as follows:
    
* Prefer the rule with the longest match for the target domain (as before)
* Among rules with the same length of target match use the rule with the longest origin domain match
    
Every rule *must* have a target domain, the origin domain is optional (origin match length is zero if missing).

Closes #15, closes #12.