### PR TITLE
Warn user about invalid rules

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -131,6 +131,16 @@
 		"message": "Konfiguration speichern",
 		"description": "Save configuration"
 	},
+	"rule missing target": {
+		"message": "Fehler: Jede Regel muss eine Zieldomain enthalten. Regel mit leerer Zieldomain und Ursprungsdomain $ORIGIN$ wird ignoriert!",
+		"description": "Error message shown when the user tries to save a rule with origin domain set and empty target domain",
+		"placeholders": {
+			"origin": {
+				"content": "$1",
+				"example": "\"www.example.com\""
+			}
+		}
+	},
 	"config backup title": {
 		"message": "Einstellungen sichern/wiederherstellen",
 		"description": "Title for the configuration backup/restore section"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -143,6 +143,16 @@
 		"message": "Save configuration",
 		"description": "Save configuration"
 	},
+	"rule missing target": {
+		"message": "Error: Every rule must have a target domain. Ignoring rule with empty target and origin $ORIGIN$!",
+		"description": "Error message shown when the user tries to save a rule with origin domain set and empty target domain",
+		"placeholders": {
+			"origin": {
+				"content": "$1",
+				"example": "\"www.example.com\""
+			}
+		}
+	},
 	"config backup title": {
 		"message": "Configuration Backup/Restore",
 		"description": "Title for the configuration backup/restore section"

--- a/options.js
+++ b/options.js
@@ -200,22 +200,31 @@ function saveOptions()
 	for (let entry of entries)
 	{
 		let host = entry.querySelector(".hostname").value.trim();
-		if (host.length > 0)
+		let origin = entry.querySelector(".origin-domain").value.trim();
+
+		if (host.length == 0)
 		{
-			let act = entry.querySelector(".action");
-			let rule = {
-				domain: host,
-				action: act.options[act.selectedIndex].value,
-				referer: entry.querySelector(".referer").value.trim()
-			};
-			let origin = entry.querySelector(".origin-domain").value.trim();
-			if (origin !== "")
+			if (origin.length > 0)
 			{
-				rule.origin = origin;
+				window.alert(browser.i18n.getMessage(
+					"rule missing target", JSON.stringify(origin)));
 			}
-			domains.push(rule);
+			continue;
 		}
+
+		let act = entry.querySelector(".action");
+		let rule = {
+			domain: host,
+			action: act.options[act.selectedIndex].value,
+			referer: entry.querySelector(".referer").value.trim()
+		};
+		if (origin !== "")
+		{
+			rule.origin = origin;
+		}
+		domains.push(rule);
 	}
+
 	let any_action = document.querySelector("#any_action");
 	let any_referer = document.querySelector("#any_referer");
 	let same_action = document.querySelector("#same_action");


### PR DESCRIPTION
A rule without a target domain is invalid, so show an alert when the user tries to save a rule with only origin domain defined. Empty rules (neither target nor origin domain set) get discarded silently.

Closes #69.