### PR TITLE
Non-persistent background script

### DIFF
--- a/background.js
+++ b/background.js
@@ -260,11 +260,14 @@ load_config();
 browser.storage.onChanged.addListener(refreshConfig);
 /* Listen for HTTP requests to modify */
 browser.webRequest.onBeforeSendHeaders.addListener(
-	async (e) => {
+	async (e) =>
+	{
 		/* Sometimes after resume reloading the config might not
 		 * finish before the listener runs otherwise. */
 		if (mod_enabled === undefined)
+		{
 			await load_config();
+		}
 		return modifyReferer(e);
 	},
 	{urls: ["<all_urls>"]},

--- a/background.js
+++ b/background.js
@@ -25,7 +25,7 @@ var engine = new RefererModEngine();
 var registeredContentScript = null;
 
 /* Modifications enabled, lets user toggle the effects */
-var mod_enabled = true;
+var mod_enabled = undefined;
 
 var config = {
 	/* Default empty domain configuration */
@@ -45,7 +45,7 @@ function genRefererHeader(value)
 	return {name: "Referer", value: value};
 }
 
-function modifyReferer(e)
+async function modifyReferer(e)
 {
 	if (!mod_enabled)
 	{
@@ -102,6 +102,7 @@ function modifyReferer(e)
 async function refreshConfig(change, area)
 {
 	let changed = false;
+
 	if (area === "sync")
 	{
 		if (Object.prototype.hasOwnProperty.call(change, "domains"))
@@ -121,10 +122,19 @@ async function refreshConfig(change, area)
 		}
 	}
 
+	if (area === "local")
+	{
+		if (Object.prototype.hasOwnProperty.call(change, "mod_enabled"))
+		{
+			mod_enabled = change.mod_enabled.newValue;
+			changed = true;
+		}
+	}
+
 	if (changed)
 	{
 		engine.setConfig(config);
-		await registerContentScript(config);
+		await update_enabled(mod_enabled);
 	}
 }
 
@@ -172,37 +182,81 @@ async function registerContentScript(config)
 }
 
 
-/* Handles messaging from the popup */
-function popup_connected(port)
+/*
+ * Set action button and content script to the requested
+ * enabled/disabled state.
+ */
+async function update_enabled(enabled)
 {
-	port.onMessage.addListener(
-		async function(m)
-		{
-			if (m.mod_enabled === null)
-			{
-				port.postMessage({mod_enabled: mod_enabled});
-			}
-			else
-			{
-				mod_enabled = m.mod_enabled;
-				console.log(`referer-mod enabled: ${mod_enabled}`);
-				if (mod_enabled)
-				{
-					await registerContentScript(config);
-					browser.browserAction.setBadgeText({text: null});
-				}
-				else
-				{
-					registeredContentScript.unregister();
-					registeredContentScript = null;
-					browser.browserAction.setBadgeText({text: "X"});
-				}
-			}
-		});
+	console.log(
+		browser.i18n.getMessage("extensionName") + " enabled: " + enabled);
+	if (enabled)
+	{
+		await registerContentScript(config);
+		browser.browserAction.setBadgeText({text: null});
+	}
+	else
+	{
+		registeredContentScript.unregister();
+		registeredContentScript = null;
+		browser.browserAction.setBadgeText({text: "X"});
+	}
 }
 
 
-browser.storage.sync.get(["domain"]).then(
+/*
+ * Load enabled/disabled state from storage, default to "true"
+ * (enabled) if unset.
+ */
+async function load_enabled()
+{
+	let result = await browser.storage.local.get(["mod_enabled"]);
+	if (result.mod_enabled !== undefined)
+	{
+		mod_enabled = result.mod_enabled;
+	}
+	else
+	{
+		mod_enabled = true;
+	}
+	await update_enabled(mod_enabled);
+}
+
+
+async function load_config()
+{
+	/* Load rules, or initialize with defaults */
+	let result = await browser.storage.sync.get(["domains", "same", "any"]);
+	if (result.domains === undefined || result.domains === null
+		|| result.same === undefined || result.same === null
+		|| result.any === undefined || result.any === null)
+	{
+		console.log(browser.i18n.getMessage("extensionName") +
+					": initialized default configuration");
+		browser.storage.sync.set({
+			domains: config.domains,
+			any: config.anyConf,
+			same: config.sameConf
+		});
+	}
+	else
+	{
+		config.domains = result.domains;
+		config.anyConf = result.any;
+		config.sameConf = result.same;
+	}
+	engine.setConfig(config);
+
+	/* Load "enabled" status */
+	await load_enabled();
+}
+
+
+/* Initialization */
+load_config();
+
+browser.runtime.onStartup.addListener(() => {
+	browser.storage.sync.get(["domain"]).then(
 	(result) =>
 	{
 		if (result.domain !== undefined)
@@ -211,43 +265,18 @@ browser.storage.sync.get(["domain"]).then(
 				.then(console.log("deleted broken legacy domain config"));
 		}
 	});
-/* Load configuration, or initialize with defaults */
-browser.storage.sync.get(["domains", "same", "any"]).then(
-	async (result) =>
-	{
-		if (result.domains === undefined || result.domains === null
-			|| result.same === undefined || result.same === null
-			|| result.any === undefined || result.any === null)
-		{
-			console.log(browser.i18n.getMessage("extensionName") +
-						": initialized default configuration");
-			browser.storage.sync.set({
-				domains: config.domains,
-				any: config.anyConf,
-				same: config.sameConf
-			});
-		}
-		else
-		{
-			config.domains = result.domains;
-			config.anyConf = result.any;
-			config.sameConf = result.same;
+});
 
-			engine.setConfig(config);
-			await registerContentScript(config);
-		}
-	},
-	(err) => console.log(browser.i18n.getMessage("extensionName") +
-						 " could not load configuration: " + err));
 /* Listen for configuration changes */
 browser.storage.onChanged.addListener(refreshConfig);
 /* Listen for HTTP requests to modify */
 browser.webRequest.onBeforeSendHeaders.addListener(
 	async (e) => {
-		return modifyReferer(e);
+		/* Sometimes after resume reloading the config might not
+		 * finish before the listener runs otherwise. */
+		if (mod_enabled === undefined)
+			await load_config();
+		return await modifyReferer(e);
 	},
 	{urls: ["<all_urls>"]},
 	["blocking", "requestHeaders"]);
-
-/* Internal messaging for toggle */
-browser.runtime.onConnect.addListener(popup_connected);

--- a/background.js
+++ b/background.js
@@ -36,6 +36,7 @@ var config = {
 	anyConf: { action: "prune", referer: "" }
 };
 
+
 /*
  * Return a header entry as required for webRequest.HttpHeaders. The
  * name is always "Referer", the value the given string.
@@ -45,7 +46,8 @@ function genRefererHeader(value)
 	return {name: "Referer", value: value};
 }
 
-async function modifyReferer(e)
+
+function modifyReferer(e)
 {
 	if (!mod_enabled)
 	{
@@ -92,7 +94,6 @@ async function modifyReferer(e)
 	}
 	return {requestHeaders: e.requestHeaders};
 }
-
 
 
 /*
@@ -264,7 +265,7 @@ browser.webRequest.onBeforeSendHeaders.addListener(
 		 * finish before the listener runs otherwise. */
 		if (mod_enabled === undefined)
 			await load_config();
-		return await modifyReferer(e);
+		return modifyReferer(e);
 	},
 	{urls: ["<all_urls>"]},
 	["blocking", "requestHeaders"]);

--- a/background.js
+++ b/background.js
@@ -243,10 +243,9 @@ browser.storage.sync.get(["domains", "same", "any"]).then(
 browser.storage.onChanged.addListener(refreshConfig);
 /* Listen for HTTP requests to modify */
 browser.webRequest.onBeforeSendHeaders.addListener(
-	(e) => new Promise((resolve) =>
-	{
-		resolve(modifyReferer(e));
-	}),
+	async (e) => {
+		return modifyReferer(e);
+	},
 	{urls: ["<all_urls>"]},
 	["blocking", "requestHeaders"]);
 

--- a/background.js
+++ b/background.js
@@ -255,18 +255,6 @@ async function load_config()
 /* Initialization */
 load_config();
 
-browser.runtime.onStartup.addListener(() => {
-	browser.storage.sync.get(["domain"]).then(
-	(result) =>
-	{
-		if (result.domain !== undefined)
-		{
-			browser.storage.sync.remove(["domain"])
-				.then(console.log("deleted broken legacy domain config"));
-		}
-	});
-});
-
 /* Listen for configuration changes */
 browser.storage.onChanged.addListener(refreshConfig);
 /* Listen for HTTP requests to modify */

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "__MSG_extensionName__",
 	"description": "__MSG_extensionDescription__",
 	"author": "Fiona Klute",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"homepage_url": "https://github.com/airtower-luna/referer-mod",
 	"default_locale": "en",
 
@@ -31,7 +31,8 @@
 	},
 
 	"background": {
-		"scripts": ["engine.js", "background.js"]
+		"scripts": ["engine.js", "background.js"],
+		"persistent": false
 	},
 
 	"content_scripts": [

--- a/popup.js
+++ b/popup.js
@@ -65,8 +65,12 @@ browser.storage.local.get(["mod_enabled"]).then(
 		if (result.mod_enabled !== undefined)
 		{
 			mod_enabled = result.mod_enabled;
-			setupPowerButton(mod_enabled);
 		}
+		else
+		{
+			mod_enabled = true;
+		}
+		setupPowerButton(mod_enabled);
 	});
 browser.storage.onChanged.addListener(refreshConfig);
 


### PR DESCRIPTION
Also called "Event Page". See [this Mozilla blog entry](https://blog.mozilla.org/addons/2022/10/31/begin-your-mv3-migration-by-implementing-new-features-today/) for the advantages. I'm not sure if there's a lot of resource saving in this specific case: Expressions have to be loaded on resume, which is a it's memory saving vs. CPU load trade-off. But the crash recovery is desirable, and it's a step towards Manifest v3 that I can take now.

Summary of the required changes:

* Use local storage instead of messaging to toggle enabled/disabled state for modifications.
* Ensure config is reloaded if undefined. This happens after resume, because variables are lost when the page is unloaded.