### PR TITLE
Register static content scripts only as needed

### DIFF
--- a/background.js
+++ b/background.js
@@ -163,9 +163,11 @@ async function registerContentScript(config)
 		"matches": ["https://*/*", "http://*/*"],
 		"matchAboutBlank": true,
 		"allFrames": true,
-		"js": [{
-			"code": code
-		}],
+		"js": [
+			{file: "engine.js"},
+			{file: "content.js"},
+			{code: code}
+		],
 		"runAt": "document_start"
 	});
 

--- a/manifest.json
+++ b/manifest.json
@@ -35,16 +35,6 @@
 		"persistent": false
 	},
 
-	"content_scripts": [
-		{
-			"matches": ["https://*/*", "http://*/*"],
-			"match_about_blank": true,
-			"all_frames": true,
-			"js": ["engine.js", "content.js"],
-			"run_at": "document_start"
-		}
-	],
-
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "referer-mod@9a5ba22d-c08f-494f-86c2-e9fd04a6a42c",


### PR DESCRIPTION
Otherwise the engine with its default configuration (prune 3rd party document.referrer) will be active even when modification is supposed to be disabled. Not loading unnecessary scripts in the first place is the best way to fix this.