### PR TITLE
Replace headless property in Firefox options class

### DIFF
--- a/test.py
+++ b/test.py
@@ -64,7 +64,7 @@ class RefModTest(unittest.TestCase):
         cls.options.set_preference('network.proxy.http', 'localhost')
         cls.options.set_preference('network.proxy.http_port', 8080)
         if not os.environ.get('DISPLAY'):
-            cls.options.headless = True
+            cls.options.add_argument('-headless')
 
         cls.browser = webdriver.Firefox(options=cls.options)
         cls.browser.install_addon(str(cls.addon_path), temporary=True)


### PR DESCRIPTION
Selenium 4.8.0 [deprecated that property](https://github.com/SeleniumHQ/selenium/blob/728db91420671a0a3e39f5a103cad5fa477ea9b6/py/CHANGES#L18), using the `-headless` argument is the suggested replacement.